### PR TITLE
Explicitly clear reference cache when working with different OAS files

### DIFF
--- a/components.js
+++ b/components.js
@@ -140,7 +140,12 @@ function getUnusedComponents(all, referenced, oas) {
   return unused;
 }
 
-const recursiveCache = {};
+let recursiveCache = {};
+
+function resetReferenceCache() {
+  recursiveCache = {};
+}
+
 function getRecursiveReferencesToComponent(oas, component, originalComponents) {
   if (recursiveCache[component]) {
     return recursiveCache[component];
@@ -170,4 +175,5 @@ module.exports = {
   getUnusedComponents,
   removeSpecifiedComponents,
   removeUnusedComponents,
+  resetReferenceCache,
 };


### PR DESCRIPTION
The global cache ugly hack optimisation broke things. If a component isn't used in one spec, it will be removed from all subsequent specs. This PR adds an explicit reset method